### PR TITLE
Update mjcf schema

### DIFF
--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -2167,10 +2167,10 @@
             <attribute name="noise" type="float"/>
             <attribute name="cutoff" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
-            <attribute name="objtype" type="keyword" required="true" valid_values="body joint geom site camera light mesh skin hfield texture material equality tendon actuator sensor numeric text tuple contact keyframe"/>
-            <attribute name="objname" type="reference" required="true" reference_namespace="attrib:objtype"/>
-            <attribute name="datatype" type="keyword" required="true" valid_values="real positive axis quaternion"/>
-            <attribute name="needstage" type="keyword" required="true" valid_values="pos vel acc"/>
+            <attribute name="objtype" type="keyword" valid_values="body joint geom site camera light mesh skin hfield texture material equality tendon actuator sensor numeric text tuple contact keyframe"/>
+            <attribute name="objname" type="reference" reference_namespace="attrib:objtype"/>
+            <attribute name="datatype" type="keyword" valid_values="real positive axis quaternion"/>
+            <attribute name="needstage" type="keyword" valid_values="pos vel acc"/>
             <attribute name="dim" type="int" required="true"/>
           </attributes>
         </element>

--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -95,6 +95,7 @@
     </element>
     <element name="size">
       <attributes>
+        <attribute name="memory" type="string"/>
         <attribute name="njmax" type="int" conflict_allowed="true" conflict_behavior="max"/>
         <attribute name="nconmax" type="int" conflict_allowed="true" conflict_behavior="max"/>
         <attribute name="nstack" type="int"/>

--- a/dm_control/mjcf/test_assets/test_model.xml
+++ b/dm_control/mjcf/test_assets/test_model.xml
@@ -42,4 +42,7 @@
     <velocity name="b_0_0" joint="b_0_0"/>
     <velocity name="b_1_0" joint="b_1_0"/>
   </actuator>
+  <sensor>
+    <user name="dummy" dim="1" user="0 1 0 1" />
+  </sensor>
 </mujoco>

--- a/dm_control/mjcf/test_assets/test_model.xml
+++ b/dm_control/mjcf/test_assets/test_model.xml
@@ -1,4 +1,5 @@
 <mujoco model="test">
+  <size memory="1K"/>
   <compiler texturedir="textures"/>
   <asset>
     <texture name="texture" type="cube" file="deepmind.png"/>


### PR DESCRIPTION
I noticed some differences between the mjcf xml schema and the [documentation's XML Reference](https://mujoco.readthedocs.io/en/stable/XMLreference.html). This fixes two of these differences:
1) `sensor/user` element's attribute defaults. The corresponding change to mujoco was made in https://github.com/deepmind/mujoco/commit/221c63d744cb3d6ea274a983eea2210881c98ce5.
2) `size` element's `memory` attribute. I believe the corrensponding change to mujoco was made in https://github.com/deepmind/mujoco/commit/58fd72f53dde9eb876aad36ac641a331b9aecc30.

Also adds two test cases through `test_model.xml`, which both fail without these schema changes.