### PR TITLE
Fix ndim-1 array to scalar conversion (Deprecated NumPy 1.25).

### DIFF
--- a/dm_control/suite/finger.py
+++ b/dm_control/suite/finger.py
@@ -153,7 +153,7 @@ class Spin(base.Task):
 
   def get_reward(self, physics):
     """Returns a sparse reward."""
-    return float(physics.hinge_velocity() <= -_SPIN_VELOCITY)
+    return float(physics.hinge_velocity().item() <= -_SPIN_VELOCITY)
 
 
 class Turn(base.Task):
@@ -195,7 +195,7 @@ class Turn(base.Task):
     return obs
 
   def get_reward(self, physics):
-    return float(physics.dist_to_target() <= 0)
+    return float(physics.dist_to_target().item() <= 0)
 
 
 def _set_random_joint_angles(physics, random, max_attempts=1000):


### PR DESCRIPTION
Hello!

As also mentioned in commit 2af59a1, NumPy 1.25 comes with a number of deprecations (https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations).

Only ndim-0 arrays are treated as scalars. Conversion of an array with ndim > 0 to a scalar is deprecated. It raises a `DeprecationWarning` under NumPy 1.25, and will be an error in the future.