### PR TITLE
Fix: compute perturbation localpos before mjv_initPerturb

### DIFF
--- a/dm_control/viewer/renderer.py
+++ b/dm_control/viewer/renderer.py
@@ -237,6 +237,11 @@ class Perturbation:
     if action is None or grab_pos is None:
       return
 
+    body_pos = self._data.xpos[self._body_id]
+    body_mat = self._data.xmat[self._body_id].reshape(3, 3)
+    grab_local_pos = body_mat.T.dot(grab_pos - body_pos)
+    self._perturb.localpos[:] = grab_local_pos
+
     mujoco.mjv_initPerturb(self._model.ptr, self._data.ptr, self._scene.ptr,
                            self._perturb.ptr)
     self._action = action
@@ -246,11 +251,6 @@ class Perturbation:
       self._perturb.active = mujoco.mjtPertBit.mjPERT_TRANSLATE
     else:
       self._perturb.active = mujoco.mjtPertBit.mjPERT_ROTATE
-
-    body_pos = self._data.xpos[self._body_id]
-    body_mat = self._data.xmat[self._body_id].reshape(3, 3)
-    grab_local_pos = body_mat.T.dot(grab_pos - body_pos)
-    self._perturb.localpos[:] = grab_local_pos
 
   def tick_move(self, viewport_offset):
     """Transforms object's location/rotation by the specified amount."""


### PR DESCRIPTION
The `mjvPerturb.localmass` is computed in `mjv_initPerturb` based on `mjvPerturb.localpos`. In the viewer application, localpos is only computed after the call to `mjv_initPerturb` in `dm_controler.viewer.renderer.Perturbation`. This can result in a large localmass which is used as inertia to compute the perturbation force and can crash the simulation (force/accelleration too large). This only happens during the first click/interaction, subsequent interactions will use the stored localpos (as long as the same body remains selected).

You can recreate this issue as follows: load up the cartpole domain in the viewer, unpause, select pole by double clicking on the body, ctrl+right click drag for force perturbation. 

```
from dm_control import suite, viewer

# Load an environment from the Control Suite.
env = suite.load(domain_name="cartpole", task_name="swingup")

# Launch the viewer application.
viewer.launch(env)
```