### PR TITLE
Add user attribute to <body> and attachment frames

### DIFF
--- a/dm_control/mjcf/schema.py
+++ b/dm_control/mjcf/schema.py
@@ -215,7 +215,7 @@ def _attachment_frame_spec(is_world_attachment):
   body_spec = MUJOCO.children['worldbody'].children['body']
   # 'name' and 'childclass' attributes are excluded.
   for attrib_name in (
-      'mocap', 'pos', 'quat', 'axisangle', 'xyaxes', 'zaxis', 'euler'):
+      'mocap', 'pos', 'quat', 'axisangle', 'xyaxes', 'zaxis', 'euler', 'user'):
     frame_spec.attributes[attrib_name] = copy.deepcopy(
         body_spec.attributes[attrib_name])
 

--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -1307,6 +1307,7 @@
             <attribute name="zaxis" type="array" array_type="float" array_size="3"/>
             <attribute name="euler" type="array" array_type="float" array_size="3"/>
             <attribute name="gravcomp" type="float"/>
+            <attribute name="user" type="array" array_type="float"/>
           </attributes>
           <children>
             <element name="plugin" repeated="true" namespace="body">


### PR DESCRIPTION
Adds the `user` attribute to the `body` tag schema to reflect the [MJCF schema](https://mujoco.readthedocs.io/en/latest/XMLreference.html#xml-schema). Also adds the `user` tag to the attachment frame schema to allow the attribute to be changed programmatically.

Fixes #459.