### PR TITLE
Update change `np.array(..., copy=False)` calls to comply with NumPy 2.0 API

### DIFF
--- a/dm_control/composer/entity.py
+++ b/dm_control/composer/entity.py
@@ -521,7 +521,7 @@ class Entity(metaclass=abc.ABCMeta):
     if position is not None:
       new_position = current_position + position
     if quaternion is not None:
-      quaternion = np.array(quaternion, dtype=np.float64, copy=False)
+      quaternion = np.asarray(quaternion, dtype=np.float64)
       new_quaternion = _multiply_quaternions(quaternion, current_quaternion)
       root_joint = mjcf.get_frame_freejoint(self.mjcf_model)
       if root_joint and rotate_velocity:

--- a/dm_control/mujoco/index.py
+++ b/dm_control/mujoco/index.py
@@ -355,7 +355,7 @@ class RegularNamedAxis(Axis):
 
     elif isinstance(key_item, (list, np.ndarray)):
       # Cast lists to numpy arrays.
-      key_item = np.array(key_item, copy=False)
+      key_item = np.asarray(key_item)
       original_shape = key_item.shape
 
       # We assume that either all or none of the items in the array are strings


### PR DESCRIPTION
Two days ago NumPy made its [version 2.0 release](https://numpy.org/doc/stable/release/2.0.0-notes.html). One of the changes in this new major release is:

> Code using `np.array(..., copy=False)` can in most cases be changed to `np.asarray(...)`. Older code tended to use `np.array` like this because it had less overhead than the default np.asarray copy-if-needed behavior. This is no longer true, and `np.asarray` is the preferred function.

(See [the NumPy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword))

As a result, `dm_control` is currently breaking (see example error stack below). This PR replaces `np.array(..., copy=False)` with `np.asarray(...)`.

Example error stack:
```
self = <dm_control.mujoco.index.RegularNamedAxis object at 0x3471565a0>
key_item = ['24/LFTarsus1', '24/LFTarsus2', '24/LFTarsus3', '24/LFTarsus4', '24/LFTarsus5', '24/LMTarsus1', ...]

    def convert_key_item(self, key_item):
      """Converts a named indexing expression to a numpy-friendly index."""

      _validate_key_item(key_item)

      if isinstance(key_item, str):
        key_item = self._names_to_offsets[util.to_native_string(key_item)]

      elif isinstance(key_item, (list, np.ndarray)):
        # Cast lists to numpy arrays.
>       key_item = np.array(key_item, copy=False)
E       ValueError: Unable to avoid copy while creating an array as requested.
E       If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
E       For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.

/opt/homebrew/Caskroom/miniforge/base/envs/xxxxx/lib/python3.12/site-packages/dm_control/mujoco/index.py:358: ValueError
```