### PR TITLE
Update setup.py to avoid TypeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,9 +132,7 @@ class InstallCommand(install.install):
     _finalize_mjbindings_options(self)
 
   def run(self):
-    self.reinitialize_command('build_mjbindings',
-                              inplace=self.inplace,
-                              headers_dir=self.headers_dir)
+    self.reinitialize_command('build_mjbindings')
     self.run_command('build_mjbindings')
     install.install.run(self)
 


### PR DESCRIPTION
Removing these lines solves the error when running pip install.     TypeError: Command.reinitialize_command() got unexpected keyword arguments:
'inplace',  'headers_dir'

Tested `pip install .` with pip version 24.1, python 3.12.3