### PR TITLE
Fix schema definition of newly introduced distance-based sensors (`fromto`, `normal`, `distance`).

### DIFF
--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -2625,11 +2625,11 @@
             <attribute name="name" type="identifier"/>
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
-            <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="cutoff" type="float" required="true"/>
+            <attribute name="geom1" type="reference" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" reference_namespace="body"/>
+            <attribute name="body2" type="reference" reference_namespace="body"/>
           </attributes>
         </element>
         <element name="normal" repeated="true" namespace="sensor">
@@ -2637,11 +2637,11 @@
             <attribute name="name" type="identifier"/>
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
-            <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="cutoff" type="float" required="true"/>
+            <attribute name="geom1" type="reference" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" reference_namespace="body"/>
+            <attribute name="body2" type="reference" reference_namespace="body"/>
           </attributes>
         </element>
         <element name="distance" repeated="true" namespace="sensor">
@@ -2649,11 +2649,11 @@
             <attribute name="name" type="identifier"/>
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
-            <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="cutoff" type="float" required="true"/>
+            <attribute name="geom1" type="reference" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" reference_namespace="body"/>
+            <attribute name="body2" type="reference" reference_namespace="body"/>
           </attributes>
         </element>
       </children>

--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -2626,10 +2626,10 @@
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
             <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="true" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="true" reference_namespace="body"/>
+            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
           </attributes>
         </element>
         <element name="normal" repeated="true" namespace="sensor">
@@ -2638,10 +2638,10 @@
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
             <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="true" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="true" reference_namespace="body"/>
+            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
           </attributes>
         </element>
         <element name="distance" repeated="true" namespace="sensor">
@@ -2650,10 +2650,10 @@
             <attribute name="noise" type="float"/>
             <attribute name="user" type="array" array_type="float"/>
             <attribute name="cutoff" type="float"/>
-            <attribute name="geom1" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="geom2" type="reference" required="true" reference_namespace="geom"/>
-            <attribute name="body1" type="reference" required="true" reference_namespace="body"/>
-            <attribute name="body2" type="reference" required="true" reference_namespace="body"/>
+            <attribute name="geom1" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="geom2" type="reference" required="false" reference_namespace="geom"/>
+            <attribute name="body1" type="reference" required="false" reference_namespace="body"/>
+            <attribute name="body2" type="reference" required="false" reference_namespace="body"/>
           </attributes>
         </element>
       </children>

--- a/dm_control/mjcf/test_assets/robot_arm.xml
+++ b/dm_control/mjcf/test_assets/robot_arm.xml
@@ -141,6 +141,8 @@
     <torque name="wristtorque" site='wristsite'/>
     <force name="baseforce" site='basesite'/>
     <torque name="basetorque" site='basesite'/>
+    <distance body1="b_finger_3" body2="b_finger_2" cutoff="0.1"/>
+    <distance geom1="finger_knuckle_3" geom2="finger_knuckle_2" cutoff="0.1"/>
   </sensor>
 
   <actuator>


### PR DESCRIPTION
This PR fixes #491.