### PR TITLE
Dev filename without hash

### DIFF
--- a/dm_control/mjcf/attribute.py
+++ b/dm_control/mjcf/attribute.py
@@ -424,7 +424,7 @@ class BaseAsset:
   def __eq__(self, other):
     return self.get_vfs_filename() == other.get_vfs_filename()
 
-  def get_vfs_filename(self):
+  def get_vfs_filename(self, filename_with_hash=True):
     """Returns the name of the asset file as registered in MuJoCo's VFS."""
     # Hash the contents of the asset to get a unique identifier.
     hash_string = hashlib.sha1(util.to_binary_string(self.contents)).hexdigest()
@@ -435,7 +435,10 @@ class BaseAsset:
       if raw_length > constants.MAX_VFS_FILENAME_LENGTH:
         trim_amount = raw_length - constants.MAX_VFS_FILENAME_LENGTH
         prefix = prefix[:-trim_amount]
-      filename = '-'.join([prefix, hash_string])
+      if filename_with_hash:
+        filename = '-'.join([prefix, hash_string])
+      else:
+        filename = prefix
     else:
       filename = hash_string
 
@@ -568,6 +571,7 @@ class File(_Attribute):
     """Returns the asset filename as it will appear in the generated XML."""
     del prefix_root  # Unused
     if self._value is not None:
-      return self._value.get_vfs_filename()
+      filename_with_hash = kwargs.get("filename_with_hash", True)
+      return self._value.get_vfs_filename(filename_with_hash)
     else:
       return None

--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -1114,7 +1114,7 @@ class _AttachmentFrameChild(_ElementImpl):
              *,
              precision=constants.XML_DEFAULT_PRECISION,
              zero_threshold=0,
-             filename_with_hash=filename_with_hash):
+             filename_with_hash=True):
     xml_element = (super().to_xml(prefix_root, debug_context,
                                   precision=precision,
                                   zero_threshold=zero_threshold,
@@ -1159,7 +1159,7 @@ class _DefaultElement(_ElementImpl):
              *,
              precision=constants.XML_DEFAULT_PRECISION,
              zero_threshold=0,
-             filename_with_hash=filename_with_hash):
+             filename_with_hash=True):
     prefix_root = prefix_root or self.namescope
     xml_element = (super().to_xml(prefix_root, debug_context,
                                   precision=precision,
@@ -1188,7 +1188,7 @@ class _ActuatorElement(_ElementImpl):
                        *,
                        precision=constants.XML_DEFAULT_PRECISION,
                        zero_threshold=0,
-                       filename_with_hash=filename_with_hash):
+                       filename_with_hash=True):
     debug_comments = {}
     for child in self.all_children():
       child_xml = child.to_xml(prefix_root, debug_context,

--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -776,7 +776,7 @@ class _ElementImpl(base.Element):
                             precision=precision, zero_threshold=zero_threshold,
                             filename_with_hash=filename_with_hash)
     self._children_to_xml(xml_element, prefix_root, debug_context,
-                          precision=precision, zero_threshold=zero_threshold)
+                          precision=precision, zero_threshold=zero_threshold,
                           filename_with_hash=filename_with_hash)
     return xml_element
 

--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -766,6 +766,8 @@ class _ElementImpl(base.Element):
         quantities.
       zero_threshold: (optional) When outputting XML, floating point quantities
         whose absolute value falls below this threshold will be treated as zero.
+      filename_with_hash: (optional) A boolean, whether to append a hash string
+        to the name of a file when it is registered in MuJoCo's VFS.
 
     Returns:
       An etree._Element object.

--- a/dm_control/mjcf/element.py
+++ b/dm_control/mjcf/element.py
@@ -1081,7 +1081,7 @@ class _AttachmentFrame(_ElementImpl):
              *,
              precision=constants.XML_DEFAULT_PRECISION,
              zero_threshold=0,
-             filename_with_hash=filename_with_hash):
+             filename_with_hash=True):
     xml_element = (super().to_xml(prefix_root, debug_context,
                                   precision=precision,
                                   zero_threshold=zero_threshold,


### PR DESCRIPTION
To deal with issue #483 without editing the source code locally, allow users to select to add a hash string after the name of the file when it is registered to VFS by specifying an optional boolean argument ```filename_with_hash```. Sample usage can be found [here](https://github.com/barikata1984/rigid_body_SE3_ctrl/blob/e473fea11ef2d4fbc93fcefd9e410b52530a65b3/core/core.py#L277).