### PR TITLE
Allow armature and damping on actuator elements

### DIFF
--- a/dm_control/mjcf/element_test.py
+++ b/dm_control/mjcf/element_test.py
@@ -800,6 +800,30 @@ class ElementTest(parameterized.TestCase):
     with self.assertRaisesRegex(TypeError, 'does not support item deletion'):
       del elem['foo']
 
+  @parameterized.parameters('general', 'motor', 'position', 'velocity',
+                            'intvelocity', 'damper', 'cylinder', 'muscle')
+  def testActuatorArmatureAndDamping(self, actuator_type):
+    # MuJoCo accepts `armature` and `damping` on these actuators, and the
+    # <default> section of the schema already allowed both, but the <actuator>
+    # elements themselves did not list them.
+    xml_string = """
+<mujoco model="test">
+  <worldbody>
+    <body>
+      <joint name="j" type="hinge"/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <{} name="a" joint="j" armature="0.7" damping="2.5"/>
+  </actuator>
+</mujoco>
+""".format(actuator_type)
+    mujoco = parser.from_xml_string(xml_string)
+    actuator = mujoco.find('actuator', 'a')
+    self.assertEqual(actuator.armature, 0.7)
+    np.testing.assert_array_equal(actuator.damping, [2.5])
+
   def testSetAndGetAttributes(self):
     mujoco = element.RootElement(model='test')
 

--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -2102,6 +2102,8 @@
             <attribute name="actrange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2135,6 +2137,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2160,6 +2164,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2190,6 +2196,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2218,6 +2226,8 @@
             <attribute name="actrange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2267,6 +2277,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2293,6 +2305,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>
@@ -2322,6 +2336,8 @@
             <attribute name="forcerange" type="array" array_type="float" array_size="2"/>
             <attribute name="lengthrange" type="array" array_type="float" array_size="2"/>
             <attribute name="gear" type="array" array_type="float" array_size="6"/>
+            <attribute name="damping" type="array" array_type="float" array_size="3"/>
+            <attribute name="armature" type="float"/>
             <attribute name="cranklength" type="float"/>
             <attribute name="joint" type="reference"/>
             <attribute name="jointinparent" type="reference" reference_namespace="joint"/>

--- a/dm_control/mjcf/xml_validation_test.py
+++ b/dm_control/mjcf/xml_validation_test.py
@@ -67,6 +67,25 @@ class XMLValidationTest(absltest.TestCase):
     model = parser.from_zip(_ZIPPED_MODEL)
     validate(model.to_xml_string(), model.get_assets())
 
+  def testActuatorArmatureAndDampingRoundTrip(self):
+    model = parser.from_xml_string("""
+<mujoco model="test">
+  <worldbody>
+    <body>
+      <joint name="j" type="hinge"/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="a" joint="j" armature="0.7" damping="2.5"/>
+  </actuator>
+</mujoco>
+""")
+    validate(model.to_xml_string())
+    mjmodel = wrapper.MjModel.from_xml_string(model.to_xml_string())
+    self.assertEqual(mjmodel.actuator_armature[0], 0.7)
+    self.assertEqual(mjmodel.actuator_damping[0], 2.5)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
MuJoCo accepts `armature` and `damping` on the `general`, `motor`, `position`, `velocity`, `intvelocity`, `damper`, `cylinder` and `muscle` actuators, and the `<default>` section of `schema.xml` already listed both for exactly those eight elements. The `<actuator>` elements themselves did not, so the attributes could only be reached through a default class and setting either one directly on an actuator raised `AttributeError: 'armature' is not a valid attribute for <position>`.

I found this by probing every attribute name in `schema.xml` against every element with MuJoCo 3.11.0 and keeping the ones MuJoCo parses but PyMJCF rejects. `armature` and `damping` on those eight actuators were the only remaining gap. I also confirmed that `adhesion` correctly rejects both, so it is left alone, and that the parsed values reach `actuator_armature` and `actuator_damping` in the compiled model. The declarations mirror the ones already used in the `<default>` block.

The new tests cover all eight actuator types and a round trip through `MjModel` that asserts the values survive. All nine fail before this change and pass after it.