### PR TITLE
Match the deformable flex and flexcomp schema to MuJoCo

### DIFF
--- a/dm_control/mjcf/schema.xml
+++ b/dm_control/mjcf/schema.xml
@@ -1257,7 +1257,7 @@
             <attribute name="texcoord" type="string"/>
             <attribute name="material" type="string"/>
             <attribute name="rgba" type="array" array_type="float" array_size="4"/>
-            <attribute name="flatskin" type="int"/>
+            <attribute name="flatskin" type="keyword" valid_values="false true"/>
             <attribute name="pos" type="array" array_type="float" array_size="3"/>
             <attribute name="quat" type="array" array_type="float" array_size="4"/>
             <attribute name="axisangle" type="array" array_type="float" array_size="4"/>
@@ -1641,7 +1641,7 @@
                 <attribute name="texcoord" type="string"/>
                 <attribute name="material" type="string"/>
                 <attribute name="rgba" type="array" array_type="float" array_size="4"/>
-                <attribute name="flatskin" type="int"/>
+                <attribute name="flatskin" type="keyword" valid_values="false true"/>
                 <attribute name="pos" type="array" array_type="float" array_size="3"/>
                 <attribute name="quat" type="array" array_type="float" array_size="4"/>
                 <attribute name="axisangle" type="array" array_type="float" array_size="4"/>
@@ -1810,18 +1810,18 @@
         <element name="flex" repeated="true" namespace="deformable">
           <attributes>
             <attribute name="name" type="identifier"/>
-            <attribute name="group" type="reference"/>
-            <attribute name="dim" type="int" required="true"/>
-            <attribute name="radius" type="float" required="true"/>
+            <attribute name="group" type="int"/>
+            <attribute name="dim" type="int"/>
+            <attribute name="radius" type="float"/>
             <attribute name="material" type="reference"/>
             <attribute name="rgba" type="array" array_type="float" array_size="4"/>
-            <attribute name="flatskin" type="array" array_type="float" array_size="2"/>
+            <attribute name="flatskin" type="keyword" valid_values="false true"/>
             <attribute name="body" type="string"/>
-            <attribute name="vertex" type="array" array_type="float" array_size="5"/>
+            <attribute name="vertex" type="array" array_type="float"/>
             <attribute name="element" type="array" array_type="int"/>
             <attribute name="texcoord" type="array" array_type="float"/>
             <attribute name="elemtexcoord" type="array" array_type="float"/>
-            <attribute name="node" type="array" array_type="float" array_size="3"/>
+            <attribute name="node" type="array" array_type="float"/>
             <attribute name="nodecoord" type="array" array_type="float"/>
             <attribute name="cellcount" type="array" array_type="int" array_size="3"/>
             <attribute name="dof" type="keyword" valid_values="trilinear quadratic"/>

--- a/dm_control/mjcf/xml_validation_test.py
+++ b/dm_control/mjcf/xml_validation_test.py
@@ -46,6 +46,47 @@ def validate(xml_string, assets=None):
 
 class XMLValidationTest(absltest.TestCase):
 
+  def testDeformableFlexRoundTrip(self):
+    # A flex needs three floats per vertex, so even the smallest one exceeds
+    # the five entries the schema used to allow. `dim` and `radius` are
+    # omitted here because MuJoCo supplies defaults for both.
+    model = parser.from_xml_string("""
+<mujoco model="test">
+  <worldbody>
+    <body name="v0"><freejoint/><geom type="sphere" size="0.01"/></body>
+    <body name="v1" pos="0.1 0 0"><freejoint/><geom type="sphere" size="0.01"/></body>
+    <body name="v2" pos="0 0.1 0"><freejoint/><geom type="sphere" size="0.01"/></body>
+  </worldbody>
+  <deformable>
+    <flex name="f" group="2" flatskin="true" body="v0 v1 v2"
+          vertex="0 0 0  0.1 0 0  0 0.1 0" element="0 1 2"/>
+  </deformable>
+</mujoco>
+""")
+    xml_string = model.to_xml_string()
+    validate(xml_string)
+    mjmodel = wrapper.MjModel.from_xml_string(xml_string)
+    self.assertEqual(mjmodel.flex_vertnum[0], 3)
+    self.assertEqual(mjmodel.flex_group[0], 2)
+    self.assertTrue(mjmodel.flex_flatskin[0])
+
+  def testFlexcompFlatskinIsBoolean(self):
+    for parent_open, parent_close in (('<body name="b">', '</body>'), ('', '')):
+      model = parser.from_xml_string("""
+<mujoco model="test">
+  <worldbody>
+    %s
+    <flexcomp name="fc" type="grid" dim="2" count="3 3 1" spacing="0.1 0.1 0.1"
+              radius="0.001" flatskin="true"/>
+    %s
+  </worldbody>
+</mujoco>
+""" % (parent_open, parent_close))
+      xml_string = model.to_xml_string()
+      validate(xml_string)
+      mjmodel = wrapper.MjModel.from_xml_string(xml_string)
+      self.assertTrue(mjmodel.flex_flatskin[0])
+
   def testXmlAttach(self):
     robot_arm = parser.from_file(_ROBOT_XML)
     arena = parser.from_file(_ARENA_XML)


### PR DESCRIPTION
The PyMJCF spec for `<deformable><flex>` disagrees with MuJoCo in several ways that together make the element unusable. The `vertex` attribute was capped at five entries, but MuJoCo reads three floats per vertex, so even a single triangle needs nine and no valid flex could ever be parsed. `node` was capped at three for the same reason, `flatskin` is a boolean keyword in MuJoCo but was declared as a pair of floats, `group` is an int but was declared as a reference into a namespace that does not exist, and `dim` and `radius` were marked required even though MuJoCo defaults them to 2 and 0.005.

The same `flatskin` mistype also appears on both copies of `<flexcomp>`, where it was declared as an int. That rejected the documented `flatskin="true"` and accepted `flatskin="1"`, which MuJoCo then refuses to compile.

This continues the type pass in cab6d38, which fixed `group`, `dim`, `radius`, `material`, `body`, `element`, `texcoord` and `elemtexcoord` on the same element but left the remaining entries wrong. Everything here was verified against mujoco 3.11.0, the version this repo pins, and the added test compiles the round-tripped XML through MuJoCo.

Verified by restoring `schema.xml` to `main` and rerunning: the round-trip test fails because `dim` is demanded, the flexcomp test fails with `Expect an integer value: got true`, and supplying `dim` and `radius` by hand then hits the `vertex` cap with `Expect array with no more than 5 entries: got` nine floats. With the change, `dm_control/mjcf/` is 152 passed and the suite and composer tests are 327 passed.

This is disjoint from my open #543 and #544. The `schema.xml` hunks are at lines 1257, 1641 and 1810 against their 606 to 932 and 2102 to 2336, and I ran trial merges against both branches with no conflicts.
