### PR TITLE
fix: replace deprecated ndarray.shape assignment (NumPy 2.5)

### DIFF
--- a/dm_control/mujoco/index.py
+++ b/dm_control/mujoco/index.py
@@ -378,7 +378,7 @@ class RegularNamedAxis(Axis):
         key_item = np.array([self._names_to_offsets[util.to_native_string(k)]
                              for k in key_item.flat])
         # Ensure the output shape is the same as that of the input.
-        key_item.shape = original_shape
+        key_item = key_item.reshape(original_shape)
 
     return key_item
 

--- a/dm_control/mujoco/index_test.py
+++ b/dm_control/mujoco/index_test.py
@@ -348,7 +348,7 @@ class AllFieldsTest(parameterized.TestCase):
     # Don't write to non-float fields since these might contain pointers.
     if np.issubdtype(old_contents.dtype, np.floating):
       new_contents = np.arange(old_contents.size, dtype=old_contents.dtype)
-      new_contents.shape = old_contents.shape
+      new_contents = new_contents.reshape(old_contents.shape)
       field[:] = new_contents
       np.testing.assert_array_equal(new_contents, field[:])
 

--- a/dm_control/mujoco/wrapper/core_test.py
+++ b/dm_control/mujoco/wrapper/core_test.py
@@ -553,7 +553,7 @@ class AttributesTest(parameterized.TestCase):
           and not np.issubdtype(target_array.dtype, np.integer)
           and not np.issubdtype(target_array.dtype, np.bool_)):
       new_contents = np.arange(target_array.size, dtype=target_array.dtype)
-      new_contents.shape = target_array.shape
+      new_contents = new_contents.reshape(target_array.shape)
       target_array[:] = new_contents
       np.testing.assert_array_equal(new_contents, target_array[:])
 


### PR DESCRIPTION
Fixes #540: setting the `shape` attribute of a NumPy array is deprecated in NumPy 2.5 (numpy/numpy#29536). Replace all `x.shape = other` usages with `x = x.reshape(other)`:

- `dm_control/mujoco/index.py` `convert_key_item`: the freshly built offset array is reshaped back to the input shape (same elements, same order — identical indexing behavior).
- `dm_control/mujoco/index_test.py` and `dm_control/mujoco/wrapper/core_test.py`: test fixtures use the same pattern when writing unique values into fields.

No behavior change.