### PR TITLE
Reshape arrays rather than setting shape on them.

### DIFF
--- a/dm_control/mujoco/index.py
+++ b/dm_control/mujoco/index.py
@@ -378,7 +378,7 @@ class RegularNamedAxis(Axis):
         key_item = np.array([self._names_to_offsets[util.to_native_string(k)]
                              for k in key_item.flat])
         # Ensure the output shape is the same as that of the input.
-        key_item.shape = original_shape
+        key_item = key_item.reshape(original_shape)
 
     return key_item
 

--- a/dm_control/mujoco/index_test.py
+++ b/dm_control/mujoco/index_test.py
@@ -347,8 +347,9 @@ class AllFieldsTest(parameterized.TestCase):
     # Write unique values to the FieldIndexer and read them back again.
     # Don't write to non-float fields since these might contain pointers.
     if np.issubdtype(old_contents.dtype, np.floating):
-      new_contents = np.arange(old_contents.size, dtype=old_contents.dtype)
-      new_contents.shape = old_contents.shape
+      new_contents = np.arange(
+          old_contents.size, dtype=old_contents.dtype
+      ).reshape(old_contents.shape)
       field[:] = new_contents
       np.testing.assert_array_equal(new_contents, field[:])
 

--- a/dm_control/mujoco/wrapper/core_test.py
+++ b/dm_control/mujoco/wrapper/core_test.py
@@ -552,8 +552,9 @@ class AttributesTest(parameterized.TestCase):
     elif (attr_name != "stack"
           and not np.issubdtype(target_array.dtype, np.integer)
           and not np.issubdtype(target_array.dtype, np.bool_)):
-      new_contents = np.arange(target_array.size, dtype=target_array.dtype)
-      new_contents.shape = target_array.shape
+      new_contents = np.arange(
+          target_array.size, dtype=target_array.dtype
+      ).reshape(target_array.shape)
       target_array[:] = new_contents
       np.testing.assert_array_equal(new_contents, target_array[:])
 


### PR DESCRIPTION
Fixes #540.

### Problem

NumPy 2.5 deprecated assigning to `ndarray.shape` ([release note](https://numpy.org/devdocs/release/2.5.0-notes.html#deprecations), [numpy#29536](https://github.com/numpy/numpy/pull/29536)).

`Axis.convert_key_item` uses it on every named index built from a list or array of names, so ordinary named indexing emits a `DeprecationWarning` under NumPy >= 2.5. Two test helpers do the same.

With `-W error::DeprecationWarning` on NumPy 2.5.2 before the change:

```
8 failed, 678 passed
```

### Fix

Use `reshape` instead. The semantics are the same at all three sites: the arrays are freshly built by `np.array`/`np.arange` and contiguous, so no copy is involved and no caller observes a difference.

### Testing

```
$ python -W error::DeprecationWarning -m pytest dm_control/mujoco/index_test.py
686 passed

$ pytest dm_control/mjcf dm_control/mujoco
1741 passed, 11 skipped
```

The one unrelated failure on my machine, `MujocoEngineTest::testRenderFlagOverridesAreNotPersistent`, fails identically without this change (headless GL).
