### PR TITLE
Support include below the root element

### DIFF
--- a/dm_control/mjcf/element_test.py
+++ b/dm_control/mjcf/element_test.py
@@ -39,6 +39,8 @@ _TEST_MODEL_XML = os.path.join(_ASSETS_DIR, 'test_model.xml')
 _TEXTURE_PATH = os.path.join(_ASSETS_DIR, 'textures/deepmind.png')
 _MESH_PATH = os.path.join(_ASSETS_DIR, 'meshes/cube.stl')
 _MODEL_WITH_INCLUDE_PATH = os.path.join(_ASSETS_DIR, 'model_with_include.xml')
+_MODEL_WITH_NESTED_INCLUDE_PATH = os.path.join(
+    _ASSETS_DIR, 'model_with_nested_include.xml')
 
 _MODEL_WITH_INVALID_FILENAMES = os.path.join(
     _ASSETS_DIR, 'model_with_invalid_filenames.xml')
@@ -850,7 +852,8 @@ class ElementTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
       ('WithoutInclude', _TEST_MODEL_XML),
-      ('WithInclude', _MODEL_WITH_INCLUDE_PATH))
+      ('WithInclude', _MODEL_WITH_INCLUDE_PATH),
+      ('WithNestedInclude', _MODEL_WITH_NESTED_INCLUDE_PATH))
   def testParseFromString(self, model_path):
     with open(model_path) as xml_file:
       xml_string = xml_file.read()
@@ -859,7 +862,8 @@ class ElementTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
       ('WithoutInclude', _TEST_MODEL_XML),
-      ('WithInclude', _MODEL_WITH_INCLUDE_PATH))
+      ('WithInclude', _MODEL_WITH_INCLUDE_PATH),
+      ('WithNestedInclude', _MODEL_WITH_NESTED_INCLUDE_PATH))
   def testParseFromFile(self, model_path):
     model_dir, _ = os.path.split(model_path)
     with open(model_path) as xml_file:
@@ -867,9 +871,24 @@ class ElementTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
       ('WithoutInclude', _TEST_MODEL_XML),
-      ('WithInclude', _MODEL_WITH_INCLUDE_PATH))
+      ('WithInclude', _MODEL_WITH_INCLUDE_PATH),
+      ('WithNestedInclude', _MODEL_WITH_NESTED_INCLUDE_PATH))
   def testParseFromPath(self, model_path):
     parser.from_path(model_path)
+
+  def testNestedIncludeIsPutInPlace(self):
+    mjcf_model = parser.from_path(_MODEL_WITH_NESTED_INCLUDE_PATH)
+
+    # The body was included inside <worldbody>, not merged at the root.
+    body = mjcf_model.find('body', 'included_body')
+    self.assertIsNotNone(body)
+    self.assertEqual(body.parent.tag, 'worldbody')
+
+    # The defaults were included inside the class that contained the tag.
+    nested = mjcf_model.default.find_all('default')[-1]
+    self.assertEqual(nested.dclass, 'nested')
+    self.assertEqual(nested.tendon.width, 0.002)
+    np.testing.assert_array_equal(nested.geom.rgba, [1, 0, 0, 1])
 
   def testGetAssetFromFile(self):
     with open(_TEXTURE_PATH, 'rb') as f:

--- a/dm_control/mjcf/parser.py
+++ b/dm_control/mjcf/parser.py
@@ -216,6 +216,10 @@ def _parse(xml_root, escape_separators=False,
       # these are a schema violation.
       xml_root.remove(include_tag)
 
+    # MuJoCo also allows <include/> further down the tree, where the contents
+    # of the included file take the place of the tag.
+    _expand_nested_includes(xml_root, model_dir, assets)
+
     # Parse the main XML file.
     try:
       model = xml_root.attrib.pop('model')
@@ -235,6 +239,55 @@ def _parse(xml_root, escape_separators=False,
     if resolve_references:
       mjcf_root.resolve_references()
     return mjcf_root
+
+
+def _read_included_xml(include_tag, model_dir, assets):
+  """Returns the root `etree.Element` of the file an `<include/>` names."""
+  filename = include_tag.attrib['file']
+  try:
+    # First look for the included XML file in the assets dict.
+    contents = assets[filename]
+  except KeyError:
+    # If it's not present in the assets dict then load it from the filesystem.
+    contents = resources.GetResource(os.path.join(model_dir, filename))
+  included_root = etree.fromstring(contents)
+  if not included_root.tag.startswith('mujoco'):
+    raise ValueError(
+        'Root element of an included file should be <mujoco.*>: got <{}> in '
+        '{!r}'.format(included_root.tag, filename))
+  return included_root
+
+
+def _expand_nested_includes(xml_element, model_dir, assets):
+  """Replaces `<include/>` tags below the root with the contents of the file.
+
+  MuJoCo allows `<include/>` wherever a child element is allowed, not only at
+  the top level, and puts the children of the included file in its place. Top
+  level includes are handled separately in `_parse`, which merges them as whole
+  models so that they keep their own asset directories.
+
+  Args:
+    xml_element: The `etree.Element` whose descendants are to be expanded.
+    model_dir: Path to the directory containing the XML file being parsed.
+    assets: A dictionary of pre-loaded assets, of the form
+      `{filename: bytestring}`.
+  """
+  for child in list(xml_element):
+    if child.tag is etree.Comment or child.tag is etree.PI:
+      continue
+    if child.tag == 'include':
+      included_root = _read_included_xml(child, model_dir, assets)
+      # A file included from a subdirectory may include further files relative
+      # to itself.
+      included_dir = os.path.join(
+          model_dir, os.path.dirname(child.attrib['file']))
+      _expand_nested_includes(included_root, included_dir, assets)
+      index = xml_element.index(child)
+      xml_element.remove(child)
+      for offset, included_child in enumerate(list(included_root)):
+        xml_element.insert(index + offset, included_child)
+    else:
+      _expand_nested_includes(child, model_dir, assets)
 
 
 def _parse_children(xml_element, mjcf_element, escape_separators=False):

--- a/dm_control/mjcf/test_assets/included_body.xml
+++ b/dm_control/mjcf/test_assets/included_body.xml
@@ -1,0 +1,6 @@
+<!-- Included by `model_with_nested_include.xml` -->
+<mujoco>
+  <body name="included_body">
+    <geom name="included_geom" class="nested" type="sphere" size="0.1"/>
+  </body>
+</mujoco>

--- a/dm_control/mjcf/test_assets/included_defaults.xml
+++ b/dm_control/mjcf/test_assets/included_defaults.xml
@@ -1,0 +1,5 @@
+<!-- Included by `model_with_nested_include.xml` -->
+<mujoco>
+  <geom rgba="1 0 0 1"/>
+  <tendon width="0.002"/>
+</mujoco>

--- a/dm_control/mjcf/test_assets/model_with_nested_include.xml
+++ b/dm_control/mjcf/test_assets/model_with_nested_include.xml
@@ -1,0 +1,11 @@
+<!-- Model with an <include/> tag below the root element -->
+<mujoco>
+  <default>
+    <default class="nested">
+      <include file="included_defaults.xml"/>
+    </default>
+  </default>
+  <worldbody>
+    <include file="included_body.xml"/>
+  </worldbody>
+</mujoco>


### PR DESCRIPTION
Fixes #529.

### Problem

`_parse` looks for includes with `xml_root.findall('include')`, which only finds direct children of `<mujoco>`. MuJoCo allows `<include/>` wherever a child element is allowed. Anything deeper is left in the tree, reaches the schema, and comes back as an error about the tag rather than about includes:

```python
mjcf.from_path('main.xml')
KeyError: "Line 3: error while parsing element <include>: 'include'"
```

for

```xml
<mujoco model="main">
  <default>
    <include file="parts.xml"/>
  </default>
  ...
```

which `mujoco.MjModel.from_xml_path` accepts. The motivating case in the issue is musculoskeletal models that group defaults per class:

```xml
<default class="forearm_muscle">
  <muscle ctrllimited="true" ctrlrange="-1 1"/>
  <tendon width="0.002"/>
</default>
```

### Fix

Expand non-root includes in place before parsing: read the named file, check its root is `<mujoco.*>`, and put its children where the tag was. Recursive, so a file included from a subdirectory can include further files relative to itself.

Top level includes are left alone. They keep going through `include_copy` as whole parsed models, so their own `model_dir` and asset handling are unchanged, and no existing model parses differently.

After:

```xml
<mujoco model="main">
  <default>
    <default class="/">
      <default class="forearm_muscle">
        <tendon width="0.002"/>
      </default>
    </default>
  </default>
  ...
```

### Testing

Three new assets and a test that the included content lands in the enclosing element rather than being merged at the root - a body included inside `<worldbody>` has `worldbody` as its parent, and defaults included inside a class end up in that class. The three existing parameterised parse tests gain a `WithNestedInclude` case.

```
$ pytest dm_control/mjcf
158 passed
```

The four new tests fail without the change to `parser.py`. I also checked the round trip compiles: `mujoco.MjModel.from_xml_string(model.to_xml_string())` on a model with an include nested two levels deep, in a subdirectory, that itself includes another file.

### Note

This picks the splice-in-place reading of nested includes, which is what MuJoCo does, rather than extending the whole-model `include_copy` path downwards. Happy to change the approach if you would rather nested includes behave like the top level ones.
